### PR TITLE
Update bigint_user_keys migration to include the db_prefix.

### DIFF
--- a/src/migrations/2015_02_07_172633_create_role_user_table.php
+++ b/src/migrations/2015_02_07_172633_create_role_user_table.php
@@ -1,62 +1,63 @@
 <?php
 
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 use Kodeine\Acl\Helper\Config;
 
 class CreateRoleUserTable extends Migration
 {
-    /**
-     * @var string
-     */
-    public $prefix;
-
-    public function __construct()
-    {
-        $this->prefix = config('acl.db_prefix');
-    }
-
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
-    public function up()
-    {
-        Schema::create($this->prefix . 'role_user', function (Blueprint $table) {
-            $table->increments('id');
-
-            $table->integer('role_id')->unsigned()->index()->foreign()->references("id")->on("roles")->onDelete("cascade");
-            $table->bigInteger('user_id')
-                ->unsigned()
-                ->index()
-                ->foreign()
-                ->references("id")
-                ->on(Config::usersTableName())
-                ->onDelete("cascade");
-
-            $table->timestamps();
-
-            $table->foreign('role_id')
-                ->references('id')
-                ->on($this->prefix . 'roles')
-                ->onDelete('cascade');
-
-            $table->foreign('user_id')
-                ->references('id')
-                ->on($this->prefix . Config::usersTableName())
-                ->onDelete('cascade');
-        });
-    }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::drop($this->prefix . 'role_user');
-    }
-
+	/**
+	 * @var string
+	 */
+	public $prefix;
+	
+	public function __construct()
+	{
+		$this->prefix = config('acl.db_prefix');
+	}
+	
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::create($this->prefix . 'role_user', function (Blueprint $table) {
+			$table->increments('id');
+			
+			$table->integer('role_id')->unsigned()->index()->foreign()->references("id")->on("roles")->onDelete("cascade");
+			$table->bigInteger($this->prefix . 'user_id')
+				->unsigned()
+				->index()
+				->foreign()
+				->references("id")
+				->on($this->prefix . Config::usersTableName())
+				->onDelete("cascade");
+			
+			$table->timestamps();
+			
+			$table->foreign('role_id')
+				->references('id')
+				->on($this->prefix . 'roles')
+				->onDelete('cascade');
+			
+			$table->foreign($this->prefix . 'user_id')
+				->references('id')
+				->on($this->prefix . Config::usersTableName())
+				->onDelete('cascade');
+		});
+	}
+	
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::drop($this->prefix . 'role_user');
+	}
+	
 }

--- a/src/migrations/2015_02_17_152439_create_permission_user_table.php
+++ b/src/migrations/2015_02_17_152439_create_permission_user_table.php
@@ -2,21 +2,22 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
 use Kodeine\Acl\Helper\Config;
 
 class CreatePermissionUserTable extends Migration
 {
-    /**
-     * @var string
-     */
-    public $prefix;
-
-    public function __construct()
-    {
-        $this->prefix = config('acl.db_prefix');
-    }
-
-    /**
+	/**
+	 * @var string
+	 */
+	public $prefix;
+	
+	public function __construct()
+	{
+		$this->prefix = config('acl.db_prefix');
+	}
+	
+	/**
 	 * Run the migrations.
 	 *
 	 * @return void
@@ -26,16 +27,16 @@ class CreatePermissionUserTable extends Migration
 		Schema::create($this->prefix . 'permission_user', function (Blueprint $table) {
 			$table->increments('id');
 			$table->integer('permission_id')->unsigned()->index()->references('id')->on('permissions')->onDelete('cascade');
-			$table->bigInteger('user_id')
-                ->unsigned()
-                ->index()
-                ->references('id')
-                ->on(Config::usersTableName())
-                ->onDelete('cascade');
+			$table->bigInteger($this->prefix . 'user_id')
+				->unsigned()
+				->index()
+				->references('id')
+				->on($this->prefix . Config::usersTableName())
+				->onDelete('cascade');
 			$table->timestamps();
 		});
 	}
-
+	
 	/**
 	 * Reverse the migrations.
 	 *
@@ -45,5 +46,4 @@ class CreatePermissionUserTable extends Migration
 	{
 		Schema::drop($this->prefix . 'permission_user');
 	}
-
 }

--- a/src/migrations/2015_11_30_232041_bigint_user_keys.php
+++ b/src/migrations/2015_11_30_232041_bigint_user_keys.php
@@ -2,30 +2,42 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+use Kodeine\Acl\Helper\Config;
 
 class BigintUserKeys extends Migration
 {
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
-    public function up()
-    {
-        Schema::table('role_user', function (Blueprint $table) {
-            $table->bigInteger("user_id")->unsigned()->change();
-        });
-    }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::table('role_user', function (Blueprint $table) {
-            $table->integer("user_id")->unsigned()->change();
-        });
-    }
+	/**
+	 * @var string
+	 */
+	public $prefix;
+	
+	public function __construct()
+	{
+		$this->prefix = config('acl.db_prefix');
+	}
+	
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table($this->prefix . 'role_user', function (Blueprint $table) {
+			$table->bigInteger("user_id")->unsigned()->change();
+		});
+	}
+	
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table($this->prefix . 'role_user', function (Blueprint $table) {
+			$table->integer("user_id")->unsigned()->change();
+		});
+	}
 }


### PR DESCRIPTION
- This will prevent exceptions thrown when running the big int conversion migration with DB prefix config.

Reproduction of: https://github.com/kodeine/laravel-acl/pull/264